### PR TITLE
Corrected the repo URL with GoDaddy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ __Please Note:__ GitHub is for bug reports and contributions only - if you have 
 * __Do not report potential security vulnerabilities here. Email them privately to me at [help at coblocks dot com](mailto:help@coblocks.com)__
 * Before submitting a ticket, please be sure to replicate the behavior with no other plugins active and on a base theme like Twenty Seventeen.
 * Submit a ticket for your issue, assuming one does not already exist.
-  * Raise it on our [Issue Tracker](https://github.com/thatplugincompany/coblocks-theme/issues)
+  * Raise it on our [Issue Tracker](https://github.com/godaddy/coblocks-theme/issues)
   * Clearly describe the issue including steps to reproduce the bug.
   * Make sure you fill in the earliest version that you know has the issue as well as the version of WordPress you're using.
 

--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@
 Need help? This is a developer's portal for CoBlocks and should not be used for general support and queries. Please visit the [CoBlocks support forum on WordPress.org](https://wordpress.org/support/theme/coblocks) if you need help using the plugin.
 
 ## Bugs ##
-If you find a 🐞 or an issue, [create an issue](https://github.com/thatplugincompany/coblocks-theme/issues/new).
+If you find a 🐞 or an issue, [create an issue](https://github.com/godaddy/coblocks-theme/issues/new).
 
 ## Contributions ##
-Please read the [guidelines for contributing](https://github.com/thatplugincompany/coblocks-theme/blob/master/CONTRIBUTING.md) to CoBlocks. Anyone is welcome to contribute!
+Please read the [guidelines for contributing](https://github.com/godaddy/coblocks-theme/blob/master/CONTRIBUTING.md) to CoBlocks. Anyone is welcome to contribute!
 
 There are various ways you can contribute:
 
-1. Raise an [Issue](https://github.com/thatplugincompany/coblocks-theme/issues/new) on GitHub
+1. Raise an [Issue](https://github.com/godaddy/coblocks-theme/issues/new) on GitHub
 2. Send a pull request with your bug fixes and/or new features
-3. Provide feedback and suggestions on [enhancements](https://github.com/thatplugincompany/coblocks-theme/issues?direction=desc&labels=Enhancement&page=1&sort=created&state=open)
+3. Provide feedback and suggestions on [enhancements](https://github.com/godaddy/coblocks-theme/issues?direction=desc&labels=Enhancement&page=1&sort=created&state=open)
 
 ## CoBlocks Plugin Screenshots
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 2. Download and install the CoBlocks theme from the [WordPress plugin directory](https://wordpress.org/theme/coblocks/).
 
 ## Development ##
-1. Clone the GitHub repository: `https://github.com/thatplugincompany/coblocks-theme.git`
+1. Clone the GitHub repository: `https://github.com/godaddy/coblocks-theme.git`
 2. Browse to the folder in the command line.
 3. Run the `npm install` command to install the theme's dependencies within a /node_modules/ folder.
 4. Run the `default` gulp task for development.


### PR DESCRIPTION
As the repo looks to be transferred from @thatplugincompany to GoDaddy as per [ref 1](https://richtabor.com/godaddy-acquires-coblocks-themebeans/) and [ref 2](https://www.godaddy.com/garage/coblocks-themebeans-tabor/), I simply corrected the repo URL to the new one to replicate the same.